### PR TITLE
chore: rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# @e18e/reporter
+# @e18e/cli
 
 This is currently a very early work in progress repository for tracking
-the new [e18e](https://e18e.dev) reporting library and CLI.
+the new [e18e](https://e18e.dev) CLI.
 
 **Nothing usable exists here yet.**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@e18e/reporter",
+  "name": "@e18e/cli",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@e18e/reporter",
+      "name": "@e18e/cli",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@e18e/reporter",
+  "name": "@e18e/cli",
   "version": "0.0.1",
   "type": "module",
-  "description": "The official e18e umbrella reporting library/CLI",
+  "description": "The official e18e CLI",
   "bin": {
     "e18e-report": "cli.js"
   },
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/e18e/reporter.git"
+    "url": "git+https://github.com/e18e/cli.git"
   },
   "keywords": [
     "e18e",
@@ -48,9 +48,9 @@
   "author": "e18e Authors (https://e18e.dev)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/e18e/reporter/issues"
+    "url": "https://github.com/e18e/cli/issues"
   },
-  "homepage": "https://github.com/e18e/reporter#readme",
+  "homepage": "https://github.com/e18e/cli#readme",
   "dependencies": {
     "@arethetypeswrong/core": "^0.17.4",
     "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@276",


### PR DESCRIPTION
Renames the package to `@e18e/cli`.

We still want to extract the logic into a reusable reporting library but can do that at a later, more stable date.