### PR TITLE
fix: use autocomplete prompt for interactive migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@arethetypeswrong/core": "^0.18.2",
-        "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@276",
+        "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
         "@publint/pack": "^0.1.2",
         "fdir": "^6.4.6",
         "gunshi": "^0.26.3",
@@ -868,9 +868,9 @@
       "integrity": "sha512-5uM+no3i3DafVgkoW7ayPhEGHNNBZCSj5TrGDQt0ayEKQda5f3lAXlmQg0MR5E0gKgmTzUUEtSWHsEC3h9jUcg=="
     },
     "node_modules/@clack/core": {
-      "version": "0.4.1",
-      "resolved": "https://pkg.pr.new/bombshell-dev/clack/@clack/core@e41b36bfe9a08a20e971f40151b71fbf8449cc8d",
-      "integrity": "sha512-6+SkOU9RVe7xaGg5/6W2MIHoCA6d4iBxpXkimqlBTsf6+EGaFVRr+bocFCKScZ/OxxGix6pnaQO8rDuQM2TFeA==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://pkg.pr.new/bombshell-dev/clack/@clack/core@9a1412da0efce5a363b85f98e8cd594f3aa81574",
+      "integrity": "sha512-S6v8X0mLyfyE9/AHTK+5tPV2oKiorOEBwY4dhbSLPTQbbv2fpegtlplRSMUK9cjDwdxR79DRQcTzCf0YeiZ1gQ==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -878,12 +878,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "0.10.0",
-      "resolved": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@276",
-      "integrity": "sha512-fDVAdQ54+Q7A/9tkIZ29rv7Op7+SAJ20VrbFt71VuSonSVvoznlYa+9OEvkf7hNUwRy4xFhZoOsLz6ImqEoWWQ==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
+      "integrity": "sha512-+EPEs3uR5+m81ZB74AldCsZCvEZJQ5dFj+hwhyzk7zRn6yRCgN/ZgLJMbD8P/akDpEWfcUTgULNzCQKMss2dKQ==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "https://pkg.pr.new/bombshell-dev/clack/@clack/core@e41b36bfe9a08a20e971f40151b71fbf8449cc8d",
+        "@clack/core": "https://pkg.pr.new/bombshell-dev/clack/@clack/core@9a1412da0efce5a363b85f98e8cd594f3aa81574",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "homepage": "https://github.com/e18e/cli#readme",
   "dependencies": {
     "@arethetypeswrong/core": "^0.18.2",
-    "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@276",
+    "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
     "@publint/pack": "^0.1.2",
     "fdir": "^6.4.6",
     "gunshi": "^0.26.3",

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -20,8 +20,9 @@ export async function run(ctx: CommandContext<typeof meta.args>) {
   prompts.intro(`Migrating packages...`);
 
   if (interactive) {
-    const additionalTargets = await prompts.multiselect({
+    const additionalTargets = await prompts.autocompleteMultiselect({
       message: 'Select packages to migrate',
+      maxItems: 10,
       options: [...fixableReplacementsTargets].map((target) => ({
         value: target,
         label: target


### PR DESCRIPTION
Switches to using an autocomplete prompt and bumps clack to get that.
