### PR TITLE
chore: cast array buffer

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -45,7 +45,7 @@ export async function run(ctx: CommandContext<typeof meta.args>) {
       const stat = await fs.stat(root);
       if (stat.isFile()) {
         const buffer = await fs.readFile(root);
-        pack = {tarball: buffer.buffer};
+        pack = {tarball: buffer.buffer as ArrayBuffer};
       } else {
         // Not a file, exit
         prompts.cancel(


### PR DESCRIPTION
Typescript decided to mess with the type of `Buffer`/`ArrayBuffer`.
Seems we have to now cast to the right type for whatever reason.
