### PR TITLE
ci: add formatting check step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: npm ci
+      - name: Check Formatting
+        run: npm run format:ci
       - name: Lint
         run: npm run lint
       - name: Build

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build": "npm run lint && npm run build:js",
     "lint": "eslint src",
     "format": "prettier --write src",
+    "format:ci": "prettier --check src",
     "test": "FORCE_COLOR=1 vitest run --coverage",
     "prepublishOnly": "npm run test",
     "generate-fixable-replacements": "node scripts/generate-fixable-replacements.ts"


### PR DESCRIPTION
as we don't use pre commit hooks (which is a blessing) this should be a good safety net

nit: we can get the script out of package.json and just inline it into action, matter of prefference