### PR TITLE
feat: move publint and attw to optional peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@arethetypeswrong/core": "^0.18.2",
         "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
         "@publint/pack": "^0.1.2",
         "debug": "^4.4.1",
@@ -19,7 +18,6 @@
         "module-replacements-codemods": "^1.2.0",
         "package-manager-detector": "^1.3.0",
         "picocolors": "^1.1.1",
-        "publint": "^0.3.12",
         "semver": "^7.7.2",
         "tinyglobby": "^0.2.14"
       },
@@ -40,6 +38,18 @@
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.39.0",
         "vitest": "^3.2.3"
+      },
+      "peerDependencies": {
+        "@arethetypeswrong/core": "^0.18.2",
+        "publint": "^0.3.12"
+      },
+      "peerDependenciesMeta": {
+        "@arethetypeswrong/core": {
+          "optional": true
+        },
+        "publint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +68,17 @@
     "node_modules/@andrewbranch/untar.js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
-      "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw=="
+      "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@arethetypeswrong/core": {
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.2.tgz",
       "integrity": "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.3",
         "@loaderkit/resolve": "^1.0.2",
@@ -84,6 +98,8 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
       "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -868,7 +884,9 @@
     "node_modules/@braidai/lang": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.1.tgz",
-      "integrity": "sha512-5uM+no3i3DafVgkoW7ayPhEGHNNBZCSj5TrGDQt0ayEKQda5f3lAXlmQg0MR5E0gKgmTzUUEtSWHsEC3h9jUcg=="
+      "integrity": "sha512-5uM+no3i3DafVgkoW7ayPhEGHNNBZCSj5TrGDQt0ayEKQda5f3lAXlmQg0MR5E0gKgmTzUUEtSWHsEC3h9jUcg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@clack/core": {
       "version": "1.0.0-alpha.1",
@@ -1618,6 +1636,8 @@
       "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.4.tgz",
       "integrity": "sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@braidai/lang": "^1.0.0"
       }
@@ -3002,7 +3022,9 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
@@ -3483,7 +3505,9 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4121,6 +4145,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
       "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -4275,6 +4301,8 @@
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4710,6 +4738,8 @@
       "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.12.tgz",
       "integrity": "sha512-1w3MMtL9iotBjm1mmXtG3Nk06wnq9UhGNRpQ2j6n1Zq7YAD6gnxMMZMIxlRPAydVjVbjSm+n0lhwqsD1m4LD5w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@publint/pack": "^0.1.2",
         "package-manager-detector": "^1.1.0",
@@ -4925,6 +4955,8 @@
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mri": "^1.1.0"
       },
@@ -5530,6 +5562,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
       "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   },
   "homepage": "https://github.com/e18e/cli#readme",
   "dependencies": {
-    "@arethetypeswrong/core": "^0.18.2",
     "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
     "@publint/pack": "^0.1.2",
     "debug": "^4.4.1",
@@ -64,9 +63,20 @@
     "module-replacements-codemods": "^1.2.0",
     "package-manager-detector": "^1.3.0",
     "picocolors": "^1.1.1",
-    "publint": "^0.3.12",
     "semver": "^7.7.2",
     "tinyglobby": "^0.2.14"
+  },
+   "peerDependencies": {
+    "@arethetypeswrong/core": "^0.18.2",
+    "publint": "^0.3.12"
+  },
+  "peerDependenciesMeta": {
+    "@arethetypeswrong/core": {
+      "optional": true
+    },
+    "publint": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/analyze/attw.ts
+++ b/src/analyze/attw.ts
@@ -1,10 +1,3 @@
-import {
-  checkPackage,
-  createPackageFromTarballData,
-  ResolutionKind
-} from '@arethetypeswrong/core';
-import {groupProblemsByKind} from '@arethetypeswrong/core/utils';
-import {filterProblems, problemKindInfo} from '@arethetypeswrong/core/problems';
 import {ReportPluginResult} from '../types.js';
 import type {FileSystem} from '../file-system.js';
 import {TarballFileSystem} from '../tarball-file-system.js';
@@ -20,6 +13,14 @@ export async function runAttw(
   if (!(fileSystem instanceof TarballFileSystem)) {
     return result;
   }
+
+  const {checkPackage, createPackageFromTarballData} = await import(
+    '@arethetypeswrong/core'
+  );
+  const {groupProblemsByKind} = await import('@arethetypeswrong/core/utils');
+  const {filterProblems, problemKindInfo} = await import(
+    '@arethetypeswrong/core/problems'
+  );
 
   const pkg = createPackageFromTarballData(new Uint8Array(fileSystem.tarball));
   const attwResult = await checkPackage(pkg);
@@ -40,7 +41,7 @@ export async function runAttw(
         const problemsForMatrix = Object.entries(
           groupProblemsByKind(
             filterProblems(attwResult, {
-              resolutionKind: resolutionKind as ResolutionKind,
+              resolutionKind: resolutionKind as any,
               entrypoint: subpath
             })
           )

--- a/src/analyze/publint.ts
+++ b/src/analyze/publint.ts
@@ -1,5 +1,3 @@
-import {publint} from 'publint';
-import {formatMessage} from 'publint/utils';
 import {ReportPluginResult} from '../types.js';
 import type {FileSystem} from '../file-system.js';
 import {TarballFileSystem} from '../tarball-file-system.js';
@@ -14,6 +12,9 @@ export async function runPublint(
   if (!(fileSystem instanceof TarballFileSystem)) {
     return result;
   }
+
+  const {publint} = await import('publint');
+  const {formatMessage} = await import('publint/utils');
 
   const publintResult = await publint({pack: {tarball: fileSystem.tarball}});
   for (const problem of publintResult.messages) {


### PR DESCRIPTION
As you review the changes, I’m curious about your perspective on the plugin system. Do you see it as simply `analyze --publint` / `analyze --attw`, or do you expect something more sophisticated?

I like how tsdown handles this (with publint integration). It runs publint after the build is successful. We can probably do the same with those 2 bad boys. As we shouldn't be dependent on a config file this seems like the easiest route