### PR TITLE
refactor: introduce plugin runner and wire report to use it

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint src",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
-    "test": "FORCE_COLOR=1 vitest run --coverage",
+    "test": "vitest run --coverage",
     "prepublishOnly": "npm run test",
     "generate-fixable-replacements": "node scripts/generate-fixable-replacements.ts"
   },

--- a/src/analyze/replacements.ts
+++ b/src/analyze/replacements.ts
@@ -31,12 +31,8 @@ export function getMdnUrl(path: string): string {
 }
 
 async function loadCustomManifests(
-  manifestPaths?: string[]
+  manifestPaths: string[]
 ): Promise<ModuleReplacement[]> {
-  if (!manifestPaths || manifestPaths.length === 0) {
-    return [];
-  }
-
   const customReplacements: ModuleReplacement[] = [];
 
   for (const manifestPath of manifestPaths) {
@@ -104,7 +100,9 @@ export async function runReplacements(
   }
 
   // Load custom manifests
-  const customReplacements = await loadCustomManifests(options?.manifest);
+  const customReplacements = options?.manifest
+    ? await loadCustomManifests(options.manifest)
+    : [];
 
   // Combine custom and built-in replacements
   const allReplacements = [

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -3,7 +3,7 @@ import {analyzePackageModuleType} from '../compute-type.js';
 import {LocalFileSystem} from '../local-file-system.js';
 import {TarballFileSystem} from '../tarball-file-system.js';
 import type {FileSystem} from '../file-system.js';
-import type {Options, ReportPlugin, Stat, Stats} from '../types.js';
+import type {Options, ReportPlugin, Stat, Stats, Message} from '../types.js';
 import {runAttw} from './attw.js';
 import {runPublint} from './publint.js';
 import {runReplacements} from './replacements.js';
@@ -37,7 +37,7 @@ export async function report(options: Options) {
   let fileSystem: FileSystem;
 
   const extraStats: Stat[] = [];
-  const baseStats: Stats = {
+  const stats: Stats = {
     name: 'unknown',
     version: 'unknown',
     dependencyCount: {
@@ -49,6 +49,7 @@ export async function report(options: Options) {
     },
     extraStats
   };
+  const messages: Message[] = [];
 
   if (pack === 'none') {
     fileSystem = new LocalFileSystem(root);
@@ -64,14 +65,9 @@ export async function report(options: Options) {
     fileSystem = new TarballFileSystem(tarball);
   }
 
-  const {messages, stats: aggregated} = await runPlugins(
-    fileSystem,
-    plugins,
-    baseStats,
-    options
-  );
+  await runPlugins(fileSystem, plugins, stats, messages, options);
 
   const info = await computeInfo(fileSystem);
 
-  return {info, messages, stats: aggregated};
+  return {info, messages, stats};
 }

--- a/src/plugin-runner.ts
+++ b/src/plugin-runner.ts
@@ -1,11 +1,6 @@
 import type {FileSystem} from './file-system.js';
 import type {Message, Options, ReportPlugin, Stats} from './types.js';
 
-interface RunPluginsResult {
-  messages: Message[];
-  stats: Stats;
-}
-
 function updateStats(
   target: Stats,
   patch: Partial<Stats>,
@@ -35,14 +30,12 @@ function updateStats(
 export async function runPlugins(
   fileSystem: FileSystem,
   plugins: ReportPlugin[],
-  baseStats: Stats,
+  stats: Stats,
+  messages: Message[],
   options?: Options
-): Promise<RunPluginsResult> {
-  const messages: Message[] = [];
-  const stats = baseStats;
-  stats.extraStats ??= [];
-
-  const seenExtra = new Set<string>(stats.extraStats.map((s) => s.name));
+): Promise<void> {
+  const extraStats = stats.extraStats ?? [];
+  const seenExtra = new Set<string>(extraStats.map((s) => s.name));
 
   for (const plugin of plugins) {
     const res = await plugin(fileSystem, options);
@@ -53,6 +46,4 @@ export async function runPlugins(
       updateStats(stats, res.stats, seenExtra);
     }
   }
-
-  return {messages, stats};
 }

--- a/src/test/custom-manifests.test.ts
+++ b/src/test/custom-manifests.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, afterEach, vi} from 'vitest';
 import {runReplacements} from '../analyze/replacements.js';
 import {LocalFileSystem} from '../local-file-system.js';
 import {join} from 'node:path';
@@ -8,6 +8,10 @@ import {dirname} from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('Custom Manifests', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should load and use custom manifest files', async () => {
     const testDir = join(__dirname, '../../test/fixtures/fake-modules');
     const fileSystem = new LocalFileSystem(testDir);
@@ -24,6 +28,7 @@ describe('Custom Manifests', () => {
   });
 
   it('should handle invalid manifest files gracefully', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const testDir = join(__dirname, '../../test/fixtures/fake-modules');
     const fileSystem = new LocalFileSystem(testDir);
     const invalidManifestPath = 'non-existent-file.json';
@@ -33,6 +38,11 @@ describe('Custom Manifests', () => {
     });
 
     expect(result.messages).toMatchSnapshot();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Warning: Failed to load custom manifest from ${invalidManifestPath}:`
+      )
+    );
   });
 
   it('should prioritize custom replacements over built-in ones', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   plugins: [
   ],
   test: {
+    env: {
+      FORCE_COLOR: '1'
+    },
     reporters: 'dot',
     include: [
       'packages/**/*.test.ts',


### PR DESCRIPTION
before: report executed plugins and merged results inline, owning all orchestration and extra stats handling.

now: report delegates to a small plugin runner that runs plugins in order and aggregates messages and stats, using a shared de-duped extraStats array.