### PR TITLE
refactor: use alpha version of `@clack/prompts`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@arethetypeswrong/core": "^0.18.2",
-        "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
+        "@clack/prompts": "^1.0.0-alpha.4",
         "@publint/pack": "^0.1.2",
         "debug": "^4.4.3",
         "fdir": "^6.5.0",
@@ -923,9 +923,9 @@
       "integrity": "sha512-5uM+no3i3DafVgkoW7ayPhEGHNNBZCSj5TrGDQt0ayEKQda5f3lAXlmQg0MR5E0gKgmTzUUEtSWHsEC3h9jUcg=="
     },
     "node_modules/@clack/core": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://pkg.pr.new/bombshell-dev/clack/@clack/core@9a1412da0efce5a363b85f98e8cd594f3aa81574",
-      "integrity": "sha512-S6v8X0mLyfyE9/AHTK+5tPV2oKiorOEBwY4dhbSLPTQbbv2fpegtlplRSMUK9cjDwdxR79DRQcTzCf0YeiZ1gQ==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-VCtU+vjyKPMSakVrB9q1bOnXN7QW/w4+YQDQCOF59GrzydW+169i0fVx/qzRRXJgt8KGj/pZZ/JxXroFZIDByg==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -933,12 +933,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
-      "integrity": "sha512-+EPEs3uR5+m81ZB74AldCsZCvEZJQ5dFj+hwhyzk7zRn6yRCgN/ZgLJMbD8P/akDpEWfcUTgULNzCQKMss2dKQ==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-KnmtDF2xQGoI5AlBme9akHtvCRV0RKAARUXHBQO2tMwnY8B08/4zPWigT7uLK25UPrMCEqnyQPkKRjNdhPbf8g==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "https://pkg.pr.new/bombshell-dev/clack/@clack/core@9a1412da0efce5a363b85f98e8cd594f3aa81574",
+        "@clack/core": "1.0.0-alpha.4",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/e18e/cli#readme",
   "dependencies": {
     "@arethetypeswrong/core": "^0.18.2",
-    "@clack/prompts": "https://pkg.pr.new/bombshell-dev/clack/@clack/prompts@9a1412d",
+    "@clack/prompts": "^1.0.0-alpha.4",
     "@publint/pack": "^0.1.2",
     "debug": "^4.4.3",
     "fdir": "^6.5.0",


### PR DESCRIPTION
Use the alpha version instead of from pkg.pr.new. The previous was pointing to [this commit](https://github.com/bombshell-dev/clack/commit/9a1412da0efce5a363b85f98e8cd594f3aa81574), and the current alpha already covers that.