### PR TITLE
fix: update replacements url

### DIFF
--- a/src/analyze/replacements.ts
+++ b/src/analyze/replacements.ts
@@ -17,7 +17,7 @@ import {LocalFileSystem} from '../local-file-system.js';
  * @return {string}
  */
 export function getDocsUrl(name: string): string {
-  return `https://github.com/es-tooling/eslint-plugin-depend/blob/main/docs/rules/${name}.md`;
+  return `https://github.com/es-tooling/module-replacements/blob/main/docs/modules/${name}.md`;
 }
 
 /**

--- a/src/test/__snapshots__/custom-manifests.test.ts.snap
+++ b/src/test/__snapshots__/custom-manifests.test.ts.snap
@@ -20,7 +20,7 @@ exports[`Custom Manifests > should load and use custom manifest files 1`] = `
     "severity": "warning",
   },
   {
-    "message": "Module "@e18e/fake-3" can be replaced with a more performant alternative. See the list of available alternatives at https://github.com/es-tooling/eslint-plugin-depend/blob/main/docs/rules/request-alternatives.md.",
+    "message": "Module "@e18e/fake-3" can be replaced with a more performant alternative. See the list of available alternatives at https://github.com/es-tooling/module-replacements/blob/main/docs/modules/request-alternatives.md.",
     "score": 0,
     "severity": "warning",
   },
@@ -50,7 +50,7 @@ exports[`Custom Manifests > should load multiple manifest files 1`] = `
     "severity": "warning",
   },
   {
-    "message": "Module "@e18e/fake-3" can be replaced with a more performant alternative. See the list of available alternatives at https://github.com/es-tooling/eslint-plugin-depend/blob/main/docs/rules/request-alternatives.md.",
+    "message": "Module "@e18e/fake-3" can be replaced with a more performant alternative. See the list of available alternatives at https://github.com/es-tooling/module-replacements/blob/main/docs/modules/request-alternatives.md.",
     "score": 0,
     "severity": "warning",
   },
@@ -91,7 +91,7 @@ exports[`Custom Manifests > should prioritize custom replacements over built-in 
       "severity": "warning",
     },
     {
-      "message": "Module "@e18e/fake-3" can be replaced with a more performant alternative. See the list of available alternatives at https://github.com/es-tooling/eslint-plugin-depend/blob/main/docs/rules/request-alternatives.md.",
+      "message": "Module "@e18e/fake-3" can be replaced with a more performant alternative. See the list of available alternatives at https://github.com/es-tooling/module-replacements/blob/main/docs/modules/request-alternatives.md.",
       "score": 0,
       "severity": "warning",
     },


### PR DESCRIPTION
The URLs for replacements currently (v0.3.1) lead to a 404 page. Apparently, they have been moved to a different repo.