### PR TITLE
perf: replace debug with obug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@clack/prompts": "^1.0.0",
         "@publint/pack": "^0.1.3",
-        "debug": "^4.4.3",
         "fdir": "^6.5.0",
         "gunshi": "^0.27.5",
         "lockparse": "^0.5.0",
         "module-replacements": "^2.11.0",
         "module-replacements-codemods": "^1.2.0",
+        "obug": "^2.1.1",
         "package-manager-detector": "^1.6.0",
         "picocolors": "^1.1.1",
         "publint": "^0.3.17",
@@ -28,7 +28,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@types/debug": "^4.1.12",
         "@types/node": "^25.2.0",
         "@types/picomatch": "^4.0.2",
         "@types/semver": "^7.7.1",
@@ -2279,16 +2278,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2307,13 +2296,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4157,7 +4139,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "git+https://github.com/e18e/cli.git"
   },
   "keywords": [
-    "e18e",    
+    "e18e",
     "dependencies",
     "dependency",
     "publint"
@@ -48,12 +48,12 @@
   "dependencies": {
     "@clack/prompts": "^1.0.0",
     "@publint/pack": "^0.1.3",
-    "debug": "^4.4.3",
     "fdir": "^6.5.0",
     "gunshi": "^0.27.5",
     "lockparse": "^0.5.0",
     "module-replacements": "^2.11.0",
     "module-replacements-codemods": "^1.2.0",
+    "obug": "^2.1.1",
     "package-manager-detector": "^1.6.0",
     "picocolors": "^1.1.1",
     "publint": "^0.3.17",
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@types/debug": "^4.1.12",
     "@types/node": "^25.2.0",
     "@types/picomatch": "^4.0.2",
     "@types/semver": "^7.7.1",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,13 @@
-import debug from 'debug';
+import {createDebug, enable} from 'obug';
 
 // Function to enable debug programmatically
 export function enableDebug(pattern: string = 'e18e:*') {
-  debug.enable(pattern);
+  enable(pattern);
 }
 
 // Create debug instances for different parts of the application
-const cliDebug = debug('e18e:cli');
-const fileSystemDebug = debug('e18e:cli:filesystem');
+const cliDebug = createDebug('e18e:cli');
+const fileSystemDebug = cliDebug.extend('filesystem');
 
 // Export the debug instances for use in different modules
 export const logger = {


### PR DESCRIPTION
https://github.com/sxzz/obug is a newly developed project, forked from [debug](https://github.com/debug-js/debug), the most popular npm library for debugging.

obug addresses several issues:

* Built-in TypeScript support—no need to install `@types/debug` (More accurate)
* Zero dependencies, achieved by dropping support for legacy browsers and older Node.js versions
  
  * Optimized for modern environments
  * Supports ES2015+ browsers
  * Compatible with Node.js 20.19 and above
* **Pure ESM**
* Extremely small footprint
  
  * Unpacked size: 21 KB vs 42 KB (including dependencies)
  * Production bundle size for browsers: only 3.22 kB, gzip: 1.5kB.
* Uses trusted publishing (although some consider this meaningless, this is simply to inform those who care about it; related discussions are outside the scope of this post)

**See [e18e/ecosystem-issues#217](https://github.com/e18e/ecosystem-issues/issues/217) for discussion**

