### PR TITLE
perf: replace picolors with native styleText

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "module-replacements-codemods": "^1.2.0",
         "obug": "^2.1.1",
         "package-manager-detector": "^1.6.0",
-        "picocolors": "^1.1.1",
         "publint": "^0.3.17",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "module-replacements-codemods": "^1.2.0",
     "obug": "^2.1.1",
     "package-manager-detector": "^1.6.0",
-    "picocolors": "^1.1.1",
     "publint": "^0.3.17",
     "semver": "^7.7.3",
     "tinyglobby": "^0.2.15"

--- a/src/analyze/duplicate-dependencies.ts
+++ b/src/analyze/duplicate-dependencies.ts
@@ -1,4 +1,4 @@
-import colors from 'picocolors';
+import {styleText} from 'node:util';
 import {ParsedLockFile, traverse, VisitorFn} from 'lockparse';
 import {AnalysisContext, Message, ReportPluginResult, Stats} from '../types.js';
 
@@ -119,11 +119,10 @@ function exportOutput(duplicateDependencies: Map<string, Version[]>) {
   }
 
   for (const [packageName, duplicate] of duplicateDependencies) {
-    const severityColor = colors.green;
-    let message = `${severityColor('[duplicate dependency]')} ${colors.bold(packageName)} has ${duplicate.length} installed versions:`;
+    let message = `${styleText('green', '[duplicate dependency]')} ${styleText('bold', packageName)} has ${duplicate.length} installed versions:`;
 
     for (const version of duplicate) {
-      message += `\n${colors.yellow(version.version)} via the following ${version.parents.length} package(s) ${colors.blue(version.parents.join(', '))}`;
+      message += `\n${styleText('yellow', version.version)} via the following ${version.parents.length} package(s) ${styleText('blue', version.parents.join(', '))}`;
     }
 
     const suggestions = generateSuggestionsForDuplicate(duplicate);
@@ -131,7 +130,7 @@ function exportOutput(duplicateDependencies: Map<string, Version[]>) {
     if (suggestions.length > 0) {
       message += '\n💡 Suggestions';
       for (const suggestion of suggestions) {
-        message += `${colors.gray(suggestion)}`;
+        message += `${styleText('gray', suggestion)}`;
       }
     }
     message += '\n';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import {createRequire} from 'node:module';
 import {cli, define, lazy, type LazyCommand} from 'gunshi';
-import c from 'picocolors';
+import {styleText} from 'node:util';
 import {meta as analyzeMeta} from './commands/analyze.meta.js';
 import {meta as migrateMeta} from './commands/migrate.meta.js';
 import {renderUsage} from 'gunshi/renderer';
@@ -32,6 +32,6 @@ const subCommands = new Map<string, LazyCommand<any>>([
 cli(process.argv.slice(2), defaultCommand, {
   name: 'cli',
   version,
-  description: `${c.cyan('e18e')}`,
+  description: `${styleText('cyan', 'e18e')}`,
   subCommands
 });

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -1,7 +1,7 @@
 import {type CommandContext} from 'gunshi';
 import {promises as fsp, type Stats} from 'node:fs';
 import * as prompts from '@clack/prompts';
-import c from 'picocolors';
+import {styleText} from 'node:util';
 import {meta} from './analyze.meta.js';
 import {report} from '../index.js';
 import {enableDebug} from '../logger.js';
@@ -95,9 +95,12 @@ export async function run(ctx: CommandContext<typeof meta>) {
 
   for (const [label, value] of summaryPairs) {
     const paddingSize = longestStatName - label.length + value.length + 2;
-    prompts.log.message(`${c.cyan(`${label}`)}${value.padStart(paddingSize)}`, {
-      spacing: 0
-    });
+    prompts.log.message(
+      `${styleText('cyan', `${label}`)}${value.padStart(paddingSize)}`,
+      {
+        spacing: 0
+      }
+    );
   }
 
   prompts.log.info('Results:');
@@ -113,27 +116,33 @@ export async function run(ctx: CommandContext<typeof meta>) {
 
     // Display errors
     if (errorMessages.length > 0) {
-      prompts.log.message(c.red('Errors:'), {spacing: 0});
+      prompts.log.message(styleText('red', 'Errors:'), {spacing: 0});
       for (const msg of errorMessages) {
-        prompts.log.message(`  ${c.red('•')} ${msg.message}`, {spacing: 0});
+        prompts.log.message(`  ${styleText('red', '•')} ${msg.message}`, {
+          spacing: 0
+        });
       }
       prompts.log.message('', {spacing: 0});
     }
 
     // Display warnings
     if (warningMessages.length > 0) {
-      prompts.log.message(c.yellow('Warnings:'), {spacing: 0});
+      prompts.log.message(styleText('yellow', 'Warnings:'), {spacing: 0});
       for (const msg of warningMessages) {
-        prompts.log.message(`  ${c.yellow('•')} ${msg.message}`, {spacing: 0});
+        prompts.log.message(`  ${styleText('yellow', '•')} ${msg.message}`, {
+          spacing: 0
+        });
       }
       prompts.log.message('', {spacing: 0});
     }
 
     // Display suggestions
     if (suggestionMessages.length > 0) {
-      prompts.log.message(c.blue('Suggestions:'), {spacing: 0});
+      prompts.log.message(styleText('blue', 'Suggestions:'), {spacing: 0});
       for (const msg of suggestionMessages) {
-        prompts.log.message(`  ${c.blue('•')} ${msg.message}`, {spacing: 0});
+        prompts.log.message(`  ${styleText('blue', '•')} ${msg.message}`, {
+          spacing: 0
+        });
       }
       prompts.log.message('', {spacing: 0});
     }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,6 +1,6 @@
 import {type CommandContext} from 'gunshi';
 import * as prompts from '@clack/prompts';
-import colors from 'picocolors';
+import {styleText} from 'node:util';
 import {meta} from './migrate.meta.js';
 import {glob} from 'tinyglobby';
 import {readFile, writeFile} from 'node:fs/promises';
@@ -88,7 +88,7 @@ export async function run(ctx: CommandContext<typeof meta>) {
       targetModules.length > 6
         ? `${targetModules.slice(0, 6).join(', ')} and ${targetModules.length - 6} more`
         : targetModules.join(', ');
-    prompts.log.message(`Targets: ${colors.dim(targetModuleSummary)}`);
+    prompts.log.message(`Targets: ${styleText('dim', targetModuleSummary)}`);
   }
 
   const cwd = ctx.env.cwd ?? process.cwd();
@@ -101,7 +101,7 @@ export async function run(ctx: CommandContext<typeof meta>) {
 
   if (files.length === 0) {
     prompts.cancel(
-      `No files found matching the pattern: ${colors.dim(include)}`
+      `No files found matching the pattern: ${styleText('dim', include)}`
     );
     return;
   }
@@ -140,7 +140,9 @@ export async function run(ctx: CommandContext<typeof meta>) {
       }
       totalMigrations++;
     }
-    log.success(`${filename} ${colors.dim(`(${totalMigrations} migrated)`)}`);
+    log.success(
+      `${filename} ${styleText('dim', `(${totalMigrations} migrated)`)}`
+    );
   }
 
   prompts.outro('Migration complete.');


### PR DESCRIPTION
Possible because it was introduced in node v20.12.0 and v20.x is the oldest we support.

So technically that means that it would crash with node v20.11.1, but I assume people interested in running this CLI are not running a node version that is 2 years old when several minor versions are available since then.