### PR TITLE
Add option for JSON output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,9 +29,13 @@ const subCommands = new Map<string, LazyCommand<any>>([
   ['migrate', lazy(migrateCommand, migrateMeta)]
 ]);
 
-cli(process.argv.slice(2), defaultCommand, {
+const args = process.argv.slice(2);
+const isJsonMode = args[0] === 'analyze' && args.includes('--json');
+
+cli(args, defaultCommand, {
   name: 'cli',
   version,
   description: `${styleText('cyan', 'e18e')}`,
-  subCommands
+  subCommands,
+  renderHeader: isJsonMode ? null : undefined
 });

--- a/src/commands/analyze.meta.ts
+++ b/src/commands/analyze.meta.ts
@@ -18,8 +18,7 @@ export const meta = {
     json: {
       type: 'boolean',
       default: false,
-      description:
-        'Write results as JSON to e18e-cli-results.json in the analyzed directory'
+      description: 'Output results as JSON to stdout'
     }
   }
 } as const;

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -1,6 +1,5 @@
 import {type CommandContext} from 'gunshi';
 import {promises as fsp, type Stats} from 'node:fs';
-import {join} from 'node:path';
 import * as prompts from '@clack/prompts';
 import {styleText} from 'node:util';
 import {meta} from './analyze.meta.js';
@@ -20,8 +19,6 @@ function formatBytes(bytes: number) {
 
   return `${size.toFixed(1)} ${units[unitIndex]}`;
 }
-
-const JSON_OUTPUT_FILENAME = 'e18e-cli-results.json';
 
 const SEVERITY_RANK: Record<string, number> = {
   error: 3,
@@ -48,7 +45,9 @@ export async function run(ctx: CommandContext<typeof meta>) {
     enableDebug('e18e:*');
   }
 
-  prompts.intro('Analyzing...');
+  if (!jsonOutput) {
+    prompts.intro('Analyzing...');
+  }
 
   // Path can be a directory (analyze project)
   if (providedPath) {
@@ -60,7 +59,11 @@ export async function run(ctx: CommandContext<typeof meta>) {
     }
 
     if (!stat || !stat.isDirectory()) {
-      prompts.cancel(`Path must be a directory: ${providedPath}`);
+      if (jsonOutput) {
+        process.stderr.write(`Path must be a directory: ${providedPath}\n`);
+      } else {
+        prompts.cancel(`Path must be a directory: ${providedPath}`);
+      }
       process.exit(1);
     }
 
@@ -81,18 +84,7 @@ export async function run(ctx: CommandContext<typeof meta>) {
     messages.some((m) => SEVERITY_RANK[m.severity] >= thresholdRank);
 
   if (jsonOutput) {
-    const outputPath = join(root ?? process.cwd(), JSON_OUTPUT_FILENAME);
-    try {
-      await fsp.writeFile(
-        outputPath,
-        JSON.stringify({stats, messages}, null, 2) + '\n'
-      );
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      prompts.cancel(`Failed to write output file: ${reason}`);
-      process.exit(1);
-    }
-    prompts.outro(`Output written to ${outputPath}`);
+    process.stdout.write(JSON.stringify({stats, messages}, null, 2) + '\n');
     if (hasFailingMessages) {
       process.exit(1);
     }

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, beforeAll, afterAll, afterEach} from 'vitest';
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
 import {spawn} from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs/promises';
@@ -165,21 +165,13 @@ describe('analyze --json', () => {
     }
   });
 
-  afterEach(async () => {
-    await fs.rm(path.join(tempDir, 'e18e-cli-results.json'), {force: true});
-    await fs.rm(path.join(basicChalkFixture, 'e18e-cli-results.json'), {
-      force: true
-    });
-  });
-
-  it('writes valid JSON to e18e-cli-results.json', async () => {
-    const {code} = await runCliProcess(
+  it('outputs valid JSON to stdout', async () => {
+    const {stdout, code} = await runCliProcess(
       ['analyze', '--json', '--log-level=error'],
       tempDir
     );
     expect(code).toBe(0);
-    const outputFile = path.join(tempDir, 'e18e-cli-results.json');
-    const parsed = JSON.parse(await fs.readFile(outputFile, 'utf8'));
+    const parsed = JSON.parse(stdout);
     expect(parsed).toHaveProperty('stats');
     expect(parsed).toHaveProperty('messages');
     expect(parsed.stats).toHaveProperty('name', 'mock-package');
@@ -189,13 +181,12 @@ describe('analyze --json', () => {
   });
 
   it('exits 1 with --json when messages meet fail threshold', async () => {
-    const {code} = await runCliProcess(
+    const {stdout, code} = await runCliProcess(
       ['analyze', '--json'],
       basicChalkFixture
     );
     expect(code).toBe(1);
-    const outputFile = path.join(basicChalkFixture, 'e18e-cli-results.json');
-    const parsed = JSON.parse(await fs.readFile(outputFile, 'utf8'));
+    const parsed = JSON.parse(stdout);
     expect(parsed.messages.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
While adding the CLI to the e18e framework tracker, it was much easier for me to work with the results as JSON.

Added a CLI flag to output JSON.
