### PR TITLE
feat: add --categories flag to filter manifests (native, preferred, micro-utilities)

### DIFF
--- a/src/analyze/replacements.ts
+++ b/src/analyze/replacements.ts
@@ -1,6 +1,7 @@
-import * as replacements from 'module-replacements';
 import type {ManifestModule, ModuleReplacement} from 'module-replacements';
 import type {ReportPluginResult, AnalysisContext} from '../types.js';
+import {getManifestByCategory} from '../categories.js';
+import type {Category} from '../categories.js';
 import {fixableReplacements} from '../commands/fixable-replacements.js';
 import {getPackageJson} from '../utils/package-json.js';
 import {resolve, dirname, basename} from 'node:path';
@@ -103,11 +104,25 @@ export async function runReplacements(
     ? await loadCustomManifests(context.options.manifest)
     : [];
 
-  // Combine custom and built-in replacements
-  const allReplacements = [
-    ...customReplacements,
-    ...replacements.all.moduleReplacements
-  ];
+  const manifestByCategory = getManifestByCategory();
+
+  const selectedCategories: readonly Category[] = context.options?.categories
+    ?.length
+    ? context.options.categories
+    : (['native', 'preferred', 'micro-utilities'] as const);
+
+  const byModuleName = new Map<string, ModuleReplacement>();
+  for (const r of customReplacements) {
+    byModuleName.set(r.moduleName, r);
+  }
+  for (const cat of selectedCategories) {
+    for (const r of manifestByCategory[cat].moduleReplacements) {
+      if (!byModuleName.has(r.moduleName)) {
+        byModuleName.set(r.moduleName, r);
+      }
+    }
+  }
+  const allReplacements = [...byModuleName.values()];
 
   const fixableByMigrate = new Set(fixableReplacements.map((r) => r.from));
 

--- a/src/categories.ts
+++ b/src/categories.ts
@@ -1,0 +1,57 @@
+import * as replacements from 'module-replacements';
+import type {ModuleReplacement} from 'module-replacements';
+
+export type CategoryFlag = 'native' | 'preferred' | 'micro-utilities' | 'all';
+export type Category = Exclude<CategoryFlag, 'all'>;
+
+export type ManifestByCategory = Record<
+  Category,
+  {moduleReplacements: ModuleReplacement[]}
+>;
+
+export function getManifestByCategory(): ManifestByCategory {
+  return {
+    native: replacements.nativeReplacements,
+    preferred: replacements.preferredReplacements,
+    'micro-utilities': replacements.microUtilsReplacements
+  };
+}
+
+export const VALID_CATEGORY_FLAGS: readonly CategoryFlag[] = [
+  'native',
+  'preferred',
+  'micro-utilities',
+  'all'
+];
+
+const ALL_CATEGORIES: readonly Category[] = [
+  'native',
+  'preferred',
+  'micro-utilities'
+];
+
+export function parseCategories(value: string | undefined): Category[] {
+  const raw = (value ?? 'all').trim().toLowerCase();
+  if (!raw) {
+    return [...ALL_CATEGORIES];
+  }
+
+  const tokens = raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  const hasAll = tokens.includes('all');
+  const categories = hasAll
+    ? [...ALL_CATEGORIES]
+    : (tokens as CategoryFlag[]).filter((t) => t !== 'all');
+
+  for (const t of categories) {
+    if (!VALID_CATEGORY_FLAGS.includes(t)) {
+      throw new Error(
+        `Invalid category "${t}". Must be one or more of: native, preferred, micro-utilities, all (comma-separated).`
+      );
+    }
+  }
+
+  return hasAll ? [...ALL_CATEGORIES] : [...new Set(categories as Category[])];
+}

--- a/src/commands/analyze.meta.ts
+++ b/src/commands/analyze.meta.ts
@@ -15,6 +15,12 @@ export const meta = {
       description:
         'Path(s) to custom manifest file(s) for module replacements analysis'
     },
+    categories: {
+      type: 'string',
+      default: 'all',
+      description:
+        'Manifest categories to use: native, preferred, micro-utilities, or all (comma-separated)'
+    },
     json: {
       type: 'boolean',
       default: false,

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -5,6 +5,7 @@ import {styleText} from 'node:util';
 import {meta} from './analyze.meta.js';
 import {report} from '../index.js';
 import {enableDebug} from '../logger.js';
+import {parseCategories, type Category} from '../categories.js';
 import {wrapAnsi} from 'fast-wrap-ansi';
 
 function formatBytes(bytes: number) {
@@ -70,12 +71,27 @@ export async function run(ctx: CommandContext<typeof meta>) {
     root = providedPath;
   }
 
-  // Then read the manifest
   const customManifests = ctx.values['manifest'];
+  let categories: readonly Category[];
+  try {
+    categories = parseCategories(
+      ctx.values['categories'] as string | undefined
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const fullMessage = `Invalid --categories: ${message} Example: --categories=all or --categories=native,preferred`;
+    if (jsonOutput) {
+      process.stderr.write(`${message}\n`);
+    } else {
+      prompts.cancel(fullMessage);
+    }
+    process.exit(1);
+  }
 
   const {stats, messages} = await report({
     root,
-    manifest: customManifests
+    manifest: customManifests,
+    categories
   });
 
   const thresholdRank = FAIL_THRESHOLD_RANK[logLevel] ?? 0;

--- a/src/commands/migrate.meta.ts
+++ b/src/commands/migrate.meta.ts
@@ -22,6 +22,12 @@ export const meta = {
       type: 'string',
       default: '**/*.{ts,js}',
       description: 'Files to migrate'
+    },
+    categories: {
+      type: 'string',
+      default: 'all',
+      description:
+        'Manifest categories to use: native, preferred, micro-utilities, or all (comma-separated). Only affects --all and interactive selection.'
     }
   }
 } as const;

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -6,8 +6,23 @@ import {glob} from 'tinyglobby';
 import {readFile, writeFile} from 'node:fs/promises';
 import {fixableReplacements} from './fixable-replacements.js';
 import type {Replacement} from '../types.js';
+import type {Category} from '../categories.js';
+import {getManifestByCategory, parseCategories} from '../categories.js';
 import {LocalFileSystem} from '../local-file-system.js';
 import {getPackageJson} from '../utils/package-json.js';
+
+function buildModuleNamesForCategories(
+  selectedCategories: readonly Category[]
+): Set<string> {
+  const manifestByCategory = getManifestByCategory();
+  const set = new Set<string>();
+  for (const cat of selectedCategories) {
+    for (const r of manifestByCategory[cat].moduleReplacements) {
+      set.add(r.moduleName);
+    }
+  }
+  return set;
+}
 
 export async function run(ctx: CommandContext<typeof meta>) {
   const [_commandName, ...targetModules] = ctx.positionals;
@@ -27,14 +42,34 @@ export async function run(ctx: CommandContext<typeof meta>) {
     return;
   }
 
+  let categories: readonly Category[];
+  try {
+    categories = parseCategories(
+      ctx.values['categories'] as string | undefined
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    prompts.cancel(
+      `Invalid --categories: ${msg} Example: --categories=all or --categories=native,preferred`
+    );
+    return;
+  }
+
   const dependencies = {
     ...packageJson.dependencies,
     ...packageJson.devDependencies
   };
 
+  const applyCategoryFilter = all || interactive;
+  const selectedCategoryModuleNames = buildModuleNamesForCategories(categories);
+
   const fixableReplacementsTargets = new Set(
     fixableReplacements
       .filter((rep) => Object.hasOwn(dependencies, rep.from))
+      .filter(
+        (rep) =>
+          !applyCategoryFilter || selectedCategoryModuleNames.has(rep.from)
+      )
       .map((rep) => rep.from)
   );
 

--- a/src/test/categories.test.ts
+++ b/src/test/categories.test.ts
@@ -1,0 +1,74 @@
+import {describe, it, expect} from 'vitest';
+import {parseCategories, VALID_CATEGORY_FLAGS} from '../categories.js';
+
+describe('parseCategories', () => {
+  it('returns all three categories when value is "all"', () => {
+    expect(parseCategories('all')).toEqual([
+      'native',
+      'preferred',
+      'micro-utilities'
+    ]);
+  });
+
+  it('returns all three categories when value is undefined', () => {
+    expect(parseCategories(undefined)).toEqual([
+      'native',
+      'preferred',
+      'micro-utilities'
+    ]);
+  });
+
+  it('returns a single category when value is one valid category', () => {
+    expect(parseCategories('native')).toEqual(['native']);
+    expect(parseCategories('preferred')).toEqual(['preferred']);
+    expect(parseCategories('micro-utilities')).toEqual(['micro-utilities']);
+  });
+
+  it('normalizes to lowercase', () => {
+    expect(parseCategories('NATIVE')).toEqual(['native']);
+    expect(parseCategories('Preferred')).toEqual(['preferred']);
+  });
+
+  it('accepts comma-separated categories', () => {
+    expect(parseCategories('native,preferred')).toEqual([
+      'native',
+      'preferred'
+    ]);
+    expect(parseCategories('native, preferred , micro-utilities')).toEqual([
+      'native',
+      'preferred',
+      'micro-utilities'
+    ]);
+  });
+
+  it('expands "all" when mixed with other categories', () => {
+    expect(parseCategories('all,native')).toEqual([
+      'native',
+      'preferred',
+      'micro-utilities'
+    ]);
+  });
+
+  it('deduplicates when same category appears multiple times', () => {
+    expect(parseCategories('native,native,preferred')).toEqual([
+      'native',
+      'preferred'
+    ]);
+  });
+
+  it('throws on invalid category', () => {
+    expect(() => parseCategories('invalid')).toThrow(
+      'Invalid category "invalid". Must be one or more of: native, preferred, micro-utilities, all (comma-separated).'
+    );
+    expect(() => parseCategories('native,foo')).toThrow(
+      'Invalid category "foo". Must be one or more of:'
+    );
+  });
+
+  it('exports valid category flags', () => {
+    expect(VALID_CATEGORY_FLAGS).toContain('native');
+    expect(VALID_CATEGORY_FLAGS).toContain('preferred');
+    expect(VALID_CATEGORY_FLAGS).toContain('micro-utilities');
+    expect(VALID_CATEGORY_FLAGS).toContain('all');
+  });
+});

--- a/src/test/custom-manifests.test.ts
+++ b/src/test/custom-manifests.test.ts
@@ -124,4 +124,24 @@ describe('Custom Manifests', () => {
 
     expect(result.messages).toMatchSnapshot();
   });
+
+  it('should filter built-in replacements by options.categories', async () => {
+    context.packageFile = {
+      ...context.packageFile,
+      dependencies: {'array-includes': '^1.0.0'}
+    };
+
+    const resultAll = await runReplacements(context);
+    context.options = {categories: ['native']};
+    const resultNative = await runReplacements(context);
+    context.options = {categories: ['preferred']};
+    const resultPreferred = await runReplacements(context);
+
+    expect(Array.isArray(resultAll.messages)).toBe(true);
+    expect(Array.isArray(resultNative.messages)).toBe(true);
+    expect(Array.isArray(resultPreferred.messages)).toBe(true);
+    expect(resultAll.messages.length).toBeGreaterThanOrEqual(0);
+    expect(resultNative.messages.length).toBeGreaterThanOrEqual(0);
+    expect(resultPreferred.messages.length).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
 import type {FileSystem} from './file-system.js';
 import type {Codemod, CodemodOptions} from 'module-replacements-codemods';
 import type {ParsedLockFile} from 'lockparse';
+import type {Category} from './categories.js';
 
 export interface Options {
   root?: string;
   manifest?: string[];
+  categories?: readonly Category[];
 }
 
 export interface StatLike<T> {


### PR DESCRIPTION
this pr adds `--categories` flag to both analyze and migrate so you can choose which module-replacement manifests get used instead of always using all of them. you can pass a single category (native, preferred, or micro-utilities), a comma separated list, or all (the default). on `analyze` it controls which replacement suggestions show up, and on migrate it only affects `--all` and the interactive picker if you pass a package name like migrate chalk it still runs no matter what categories you picked.